### PR TITLE
Add summary output of failed cucumber scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp
 Gemfile.lock
 doc
 *.gem
+*.un~

--- a/features/output.feature
+++ b/features/output.feature
@@ -3,7 +3,7 @@ Feature: Output
   I want familiar cucumber output
 
   Scenario: success
-    Given a cucumber suite with two features that each sleep for 1 second
+    Given a cucumber suite with two features that each sleep for 2 second
     When I run flatware
     Then the output contains the following:
     """
@@ -21,6 +21,11 @@ Feature: Output
     """
     When I run flatware
     Then the output contains a backtrace
+
+  Scenario: multiple failure
+    Given a cucumber suite with two features that each fail
+    When I run flatware
+    Then the output contains a summary of failing features
 
   Scenario: outlines
     Given the following scenario:

--- a/features/step_definitions/flatware_steps.rb
+++ b/features/step_definitions/flatware_steps.rb
@@ -78,10 +78,14 @@ Then /^the output contains the following:$/ do |string|
   assert_partial_output string, all_output
 end
 
-Given 'the following scenario:' do |scenario|
+def create_flunk_step_definition
   write_file "features/step_definitions/flunky_steps.rb", <<-RB
     Then('flunk') { false.should be_true }
   RB
+end
+
+Given 'the following scenario:' do |scenario|
+  create_flunk_step_definition
 
   write_file "features/flunk.feature", <<-FEATURE
   Feature: flunk
@@ -104,4 +108,28 @@ Then /^I see that (#{A.number}) (scenario|step)s? (?:was|where) run$/ do |count,
   match = all_output.match(/^(?<count>\d+) #{thing}s?/)
   match.should be
   match[:count].to_i.should eq count
+end
+
+Given /^a cucumber suite with two features that each fail$/ do
+  create_flunk_step_definition
+
+  2.times do |feature_number|
+    write_file "features/failing_feature_#{feature_number}.feature", <<-FEATURE
+    Feature: flunking
+
+    Scenario: flunk
+      Given flunk
+    FEATURE
+  end
+end
+
+Then 'the output contains a summary of failing features' do
+
+  trace = <<-TXT.gsub(/^ +/, '')
+    Failing Scenarios:
+    features/failing_feature_1.feature:3 # Scenario: flunk
+    features/failing_feature_0.feature:3 # Scenario: flunk
+  TXT
+
+  assert_partial_output trace, all_output
 end

--- a/lib/flatware.rb
+++ b/lib/flatware.rb
@@ -12,6 +12,7 @@ module Flatware
   autoload :StepResult, 'flatware/step_result'
   autoload :Summary, 'flatware/summary'
   autoload :Worker, 'flatware/worker'
+  autoload :ScenarioDecorator, 'flatware/scenario_decorator'
 
   Job = Struct.new :id, :args
 

--- a/lib/flatware/checkpoint.rb
+++ b/lib/flatware/checkpoint.rb
@@ -15,8 +15,9 @@ module Flatware
 
     def serialize_scenarios(scenarios)
       scenarios.map do |scenario|
-        ScenarioResult.new scenario.status
+        ScenarioResult.new scenario.status, scenario.file_colon_line, scenario.name
       end
     end
+
   end
 end

--- a/lib/flatware/cucumber/formatter.rb
+++ b/lib/flatware/cucumber/formatter.rb
@@ -1,5 +1,6 @@
 require 'cucumber/formatter/console'
 require 'flatware/checkpoint'
+require 'flatware/scenario_decorator'
 module Flatware
   module Cucumber
     class Formatter
@@ -34,7 +35,7 @@ module Flatware
         end
 
         def checkpoint
-          Checkpoint.new(step_mother.steps - @ran_steps, step_mother.scenarios - @ran_scenarios).tap do
+          Checkpoint.new(step_mother.steps - @ran_steps, decorate_scenarios(step_mother.scenarios - @ran_scenarios)).tap do
             snapshot
           end
         end
@@ -44,6 +45,10 @@ module Flatware
         def snapshot
           @ran_steps = step_mother.steps.dup
           @ran_scenarios = step_mother.scenarios.dup
+        end
+
+        def decorate_scenarios(scenarios)
+          scenarios.map { |scenario| ScenarioDecorator.new(scenario) }
         end
       end
     end

--- a/lib/flatware/scenario_decorator.rb
+++ b/lib/flatware/scenario_decorator.rb
@@ -1,0 +1,18 @@
+module Flatware
+  class ScenarioDecorator
+    def initialize(scenario)
+      @scenario = scenario
+    end
+
+    %w(file_colon_line name).each do |get|
+      define_method "#{get}" do
+        @scenario.respond_to?(:scenario_outline) ? @scenario.scenario_outline.send("#{get}") : @scenario.send("#{get}")
+      end
+    end
+
+    def status
+      @scenario.status
+    end
+
+  end
+end

--- a/lib/flatware/scenario_result.rb
+++ b/lib/flatware/scenario_result.rb
@@ -1,8 +1,10 @@
 module Flatware
   class ScenarioResult
-    attr_reader :status
-    def initialize(status)
+    attr_reader :status, :file_colon_line, :name
+    def initialize(status, file_colon_line, name)
       @status = status
+      @file_colon_line = file_colon_line
+      @name = name
     end
 
     def passed?

--- a/lib/flatware/summary.rb
+++ b/lib/flatware/summary.rb
@@ -14,11 +14,22 @@ module Flatware
     def summarize
       2.times { io.puts }
       print_steps :failed
+      print_failed_scenarios scenarios
       print_counts 'scenario', scenarios
       print_counts 'step', steps
     end
 
     private
+
+    def print_failed_scenarios(scenarios)
+      return "" unless scenarios.select(&with_status(:failed)).size > 0
+      io.puts format_string "Failing Scenarios:", :failed
+
+      scenarios.select(&with_status(:failed)).each do |scenario|
+        io.puts format_string(scenario.file_colon_line, :failed) + format_string(" # Scenario: " + scenario.name, :comment)
+      end
+      io.puts
+    end
 
     def print_steps(status)
       print_elements steps.select(&with_status(status)), status, 'steps'

--- a/spec/flatware/scenario_decorator_spec.rb
+++ b/spec/flatware/scenario_decorator_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Flatware::ScenarioDecorator do
+  let(:scenario) { stub file_colon_line: "features/file_line.feature:3", name: "scenario_name", status: :passed }
+  let(:scenario_outline) { stub file_colon_line: "features/outline.feature:3", name: "outline_name" }
+  let(:example_row) { stub scenario_outline: scenario_outline, status: :passed }
+
+  context 'with scenario' do
+    subject { Flatware::ScenarioDecorator.new(scenario) }
+    it { subject.file_colon_line.should eq scenario.file_colon_line }
+    it { subject.name.should eq scenario.name }
+    it { subject.status.should eq scenario.status }
+  end
+
+  context 'with example row' do
+    subject { Flatware::ScenarioDecorator.new(example_row) }
+    it { subject.file_colon_line.should eq example_row.scenario_outline.file_colon_line }
+    it { subject.name.should eq example_row.scenario_outline.name }
+    it { subject.status.should eq example_row.status }
+  end
+
+end

--- a/spec/flatware/summary_spec.rb
+++ b/spec/flatware/summary_spec.rb
@@ -4,7 +4,8 @@ describe Flatware::Summary do
   let(:summary) { described_class.new steps, scenarios, io }
   let(:io) { StringIO.new }
   let(:passed) { stub status: :passed, failed?: false }
-  let(:failed) { stub status: :failed, failed?: true, exception: exception }
+  let(:failed) { stub status: :failed, failed?: true, exception: exception, file_colon_line: "features/failed.feature:3", name: "failed" }
+  let(:failed2) { stub status: :failed, failed?: true, exception: exception, file_colon_line: "features/failed_2.feature:8", name: "failed_2" }
 
   let(:exception) do
     stub backtrace: %w'backtrace', message: 'message', class: 'class'
@@ -19,6 +20,15 @@ describe Flatware::Summary do
   context 'with a passed scenario' do
     let(:scenarios) { [passed] }
     it { should include %[1 scenario (1 passed)] }
+  end
+
+  context 'with 2 failed scenarios' do
+    let(:scenarios) { [failed, failed2] }
+    it 'displays a list of failed scenarios' do
+      should include 'Failing Scenarios:'
+      should include 'features/failed.feature'
+      should include 'features/failed_2.feature'
+    end
   end
 
   context 'with one passed and one failed scenario' do
@@ -41,6 +51,7 @@ describe Flatware::Summary do
       should include 'backtrace'
     end
   end
+
 end
 
 


### PR DESCRIPTION
For issue:
https://github.com/briandunn/flatware/issues/4

Example:

> ---UUUU
> 
> (::) failed steps (::)
> 
> expected: true value
>      got: false (RSpec::Expectations::ExpectationNotMetError)
> ./features/step_definitions/flunky_steps.rb:1:in `/^flunk$/'
> features/flunk.feature:4:in`Given <animal>'
> 
> Failing Scenarios:
> features/flunk.feature:3 # Scenario: old McDonnald
> 
> 2 scenarios (1 failed, 1 undefined)
> 6 steps (1 failed, 5 undefined)
