### PR TITLE
Exit with non-zero exit status on step failure

### DIFF
--- a/features/step_definitions/flatware_steps.rb
+++ b/features/step_definitions/flatware_steps.rb
@@ -83,7 +83,6 @@ When /^I time the suite with (#{runners})$/ do |runner|
   @durations[runner] = duration do
     run_simple commands[runner], false
   end
-  assert_exit_status 0
 end
 
 Then /^(#{runners}) is the fastest$/ do |runner|
@@ -162,4 +161,5 @@ end
 Then 'the failure list only includes one feature' do
   all_output.match /Failing Scenarios:\n(.+?)(?=\n\n)/m
   $1.split("\n").should have(1).feature
+  assert_exit_status 1
 end

--- a/lib/flatware/checkpoint_handler.rb
+++ b/lib/flatware/checkpoint_handler.rb
@@ -19,9 +19,23 @@ module Flatware
     end
 
     def summarize
-      steps = @checkpoints.map(&:steps).flatten
-      scenarios = @checkpoints.map(&:scenarios).flatten
-      Summary.new(steps, scenarios, @out).summarize
+      summary.summarize
+    end
+
+    def steps
+      @steps ||= @checkpoints.map(&:steps).flatten
+    end
+
+    def scenarios
+      @scenarios ||= @checkpoints.map(&:scenarios).flatten
+    end
+
+    def summary
+      @summary ||= Summary.new(steps, scenarios, @out)
+    end
+
+    def had_failures?
+      summary.had_failures?
     end
   end
 end

--- a/lib/flatware/sink.rb
+++ b/lib/flatware/sink.rb
@@ -57,6 +57,7 @@ module Flatware
           end
         end
         checkpoint_handler.summarize
+        exit 1 if checkpoint_handler.had_failures?
       rescue Error => e
         raise unless e.message == "Interrupted system call"
       end

--- a/lib/flatware/summary.rb
+++ b/lib/flatware/summary.rb
@@ -19,10 +19,14 @@ module Flatware
       print_counts 'step', steps
     end
 
+    def had_failures?
+      scenarios.any? &with_status(:failed)
+    end
+
     private
 
     def print_failed_scenarios(scenarios)
-      return unless scenarios.any? &with_status(:failed)
+      return unless had_failures?
 
       io.puts format_string "Failing Scenarios:", :failed
       scenarios.select(&with_status(:failed)).sort_by(&:file_colon_line).each do |scenario|


### PR DESCRIPTION
This should fix the issue where flatware exits with 0 even though
a step / scenario failed. No more pushing red!
