### PR TITLE
ensure all child processes receive kill message on exit

### DIFF
--- a/features/child_processes_close.feature
+++ b/features/child_processes_close.feature
@@ -1,0 +1,7 @@
+Feature: child processes close
+  The parent process must ensure that all processes it forks are closed
+
+  Scenario: ensure that all processes are closed
+    Given a cucumber suite with a feature that fails
+    When I run flatware with "--child-pids"
+    Then I see that none of the child pids exist as processes

--- a/lib/flatware/sink.rb
+++ b/lib/flatware/sink.rb
@@ -83,7 +83,12 @@ module Flatware
       def before_firing(&block)
         Flatware::Fireable::bind
         block.call
-        Flatware::Fireable::kill
+      ensure
+        begin
+          Flatware::Fireable::kill
+        rescue Flatware::Error => error
+          log "error while trying to send kill message on exit", error.message
+        end
       end
 
       def completed_jobs

--- a/lib/flatware/worker.rb
+++ b/lib/flatware/worker.rb
@@ -7,7 +7,7 @@ module Flatware
     end
 
     def self.spawn(worker_count)
-      worker_count.times do |i|
+      worker_count.times.map do |i|
         fork do
           $0 = "flatware worker #{i}"
           ENV['TEST_ENV_NUMBER'] = i.to_s

--- a/spec/flatware/sink_spec.rb
+++ b/spec/flatware/sink_spec.rb
@@ -10,7 +10,10 @@ describe Flatware::Sink do
 
     before do
       unless @child_io = IO.popen("-")
-        described_class.start_server [job]
+        formatter = double 'Formatter'
+        formatter.should_receive :summarize
+        formatter.should_receive :summarize_remaining
+        described_class.start_server [job], formatter
       end
     end
 
@@ -19,7 +22,8 @@ describe Flatware::Sink do
       pid = child_pids.first
       Process.kill 'INT', pid
       Process.wait pid
-      child_io.read.should match /SystemExit:/
+      child_io_output = child_io.read
+      child_io_output.should match /SystemExit:/
       child_pids.should_not include pid
     end
   end


### PR DESCRIPTION
The sink is responsible for sending a kill message to the dispatcher (and workers) but when the suite experiences a failure, exit is called without sending that kill message.  The kill message is placed in an ensure block so that the kill message is sent in both the 'all tests passed' case and the 'test failed' case.

The code added for creating a scenario is... maybe not so cool... but it demonstrates the failure without the ensure block and success with that block.  Maybe child-pids shouldn't be part of the flatware options though.
