### PR TITLE
pids on linux system (no -c option)

### DIFF
--- a/lib/flatware/pids.rb
+++ b/lib/flatware/pids.rb
@@ -2,8 +2,17 @@ module Flatware
   extend self
   # All the pids of all the processes called flatware on this machine
   def pids
-    `ps -c -opid,command`.split("\n").map do |row|
+    pids_command.split("\n").map do |row|
       row =~ /(\d+).*flatware/ and $1.to_i
     end.compact
+  end
+
+  def pids_command
+    case ProcessorInfo.operating_system
+    when 'Darwin'
+      `ps -c -opid,command`
+    when 'Linux'
+      `ps -opid,command`
+    end
   end
 end

--- a/lib/flatware/processor_info.rb
+++ b/lib/flatware/processor_info.rb
@@ -16,5 +16,9 @@ module Flatware
     def self.count
       new.count
     end
+
+    def self.operating_system
+      new.operating_system
+    end
   end
 end


### PR DESCRIPTION
Linux doesn't have the -c option for determining which command line statement to display.

http://manpages.ubuntu.com/manpages/quantal/en/man1/ps.1.html

ps -opid,command will output

  PID COMMAND
 8461 flatware sink  
 8476 flatware worker 3  
 9396 ps -opid,command
29006 -bash

This fixes `flatware clear` which didn't previously work on my linux system and this also stops the warning "Warning: bad ps syntax, perhaps a bogus '-'? See http://procps.sf.net/faq.html" from printing when `ps -c` is called.
