### PR TITLE
unless the scenario passed, dont assert the exit status

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -43,10 +43,10 @@ Before { @flatware_pids = Flatware.pids }
 After { (Flatware.pids - @flatware_pids).should have(0).zombies }
 
 
-After '~@non-zero' do
-  assert_exit_status 0
+After '~@non-zero' do |scenario|
+  scenario.status == :passed and assert_exit_status 0
 end
 
-After '@non-zero' do
-  assert_exit_status 1
+After '@non-zero' do |scenario|
+  scenario.status == :passed and assert_exit_status 1
 end


### PR DESCRIPTION
The TERM scenario was failing in the After hook because it didn't have an exit status even, though all of its steps were skipped.  This commit checks that the scenario has passed before asserting the exit status.
