### PR TITLE
make flatware the group leader always; check for group pids after the sc...

### DIFF
--- a/features/support/flatware/spawn_process.rb
+++ b/features/support/flatware/spawn_process.rb
@@ -1,0 +1,8 @@
+module Flatware
+  class SpawnProcess < Aruba::SpawnProcess
+    attr_reader :pid
+    def run!
+      super { |process| @pid = @process.pid }
+    end
+  end
+end

--- a/lib/flatware/cli.rb
+++ b/lib/flatware/cli.rb
@@ -25,6 +25,7 @@ module Flatware
     method_option 'formatters', aliases: "-f", type: :array, default: %w[console], desc: "The formatters to use for output"
     desc "[FLATWARE_OPTS] cucumber [CUCUMBER_ARGS]", "parallelizes cucumber with custom arguments"
     def cucumber(*)
+      Process.setpgrp
       Flatware.verbose = options[:log]
       log "flatware options:", options
       log "cucumber options:", cucumber_args

--- a/lib/flatware/pids.rb
+++ b/lib/flatware/pids.rb
@@ -10,9 +10,15 @@ module Flatware
   def pids_command
     case ProcessorInfo.operating_system
     when 'Darwin'
-      `ps -c -opid,command`
+      `ps -c -opid,command,pgid`
     when 'Linux'
-      `ps -opid,command`
+      `ps -opid,command,pgid`
     end
+  end
+
+  def pids_of_group(group_pid)
+    pids_command.split("\n").map do |row|
+      row =~ /(\d+).*flatware.*(#{group_pid})/ and $1.to_i
+    end.compact
   end
 end

--- a/spec/flatware/pids_spec.rb
+++ b/spec/flatware/pids_spec.rb
@@ -1,0 +1,16 @@
+require './lib/flatware/pids'
+require './lib/flatware/processor_info'
+
+describe 'pids' do
+  context 'group pids' do
+    it 'should get all the pids of a group' do
+      @group_leader_pid = Process.pid
+      $0 = "flatware group leader"
+      @child_pid = fork {
+        $0 = "flatware child"
+        sleep 1
+      }
+      Flatware.pids_of_group(@group_leader_pid).should include @group_leader_pid, @child_pid
+    end
+  end
+end


### PR DESCRIPTION
...enario

Although all the cucumber scenarios passed when running `cucumber`, a number of cucumber scenarios failed when running `flatware cucumber`.  These failures were due to the after hook checking for flatware processes and finding the flatware processes of the other tests running in parallel.

This solution checks for pids that have the group id of the flatware process.  Its enabled by making flatware the group leader for all cases.  Previously flatware was the group leader when run from the command line but wasn't the group leader when run from cucumber/aruba.  I have no idea what the down-the-road consequences might be of making flatware the group leader, but it feels right.

The solution is also enabled by subclassing Aruba's SpawnProcess class in order to gain access to the pid.  I think Aruba doesn't allow access to the pid because its trying to remain OS agnostic, but flatware is a unix-flavor app, so this hack should be helpful in testing a pid heavy command-line tool, I think/hope!
