### PR TITLE
Instruct user not to require gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ brew install zeromq
 Add the runners you need to your Gemfile:
 
 ```ruby
-gem 'flatware-rspec'    # one
-gem 'flatware-cucumber' # or both
+gem 'flatware-rspec', require: false    # one
+gem 'flatware-cucumber', require: false # or both
 ```
 
 then run


### PR DESCRIPTION
If a developer does not have the required dependencies installed, they won't be able to run the tests, even if they aren't using flatware. Similarly, CI servers will fail if they don't have the dependencies, regardless of whether or not they are running the tests in parallel.

This is a proposed workaround; because the user only interacts with flatware through the CLI, neither gem has to be required to work.