### PR TITLE
Replace append its alias target push

### DIFF
--- a/lib/flatware/rspec/job_builder.rb
+++ b/lib/flatware/rspec/job_builder.rb
@@ -41,9 +41,9 @@ module Flatware
                                        [[], []]
                                      ) do |(timed, untimed), file|
           if (time = seconds_per_file[file])
-            [timed.append([file, time]), untimed]
+            [timed.push([file, time]), untimed]
           else
-            [timed, untimed.append(file)]
+            [timed, untimed.push(file)]
           end
         end
 


### PR DESCRIPTION
TravisCI build #198 is failing on Ruby 2.3.1 due to the use of `append`. `append` is an alias for `push` and was introduced in Ruby 2.5. To support older Ruby versions, better to use the older method.

### Steps to Test

```
$ rspec
```