### PR TITLE
RSpec output assertion is rspec-support 3.8.2 compatible

### DIFF
--- a/features/rspec.feature
+++ b/features/rspec.feature
@@ -3,30 +3,33 @@ Feature: rspec task
   @non-zero
   Scenario: failure messages
     Given the following spec:
-    """
-    describe "fail" do
+      """
+      describe "fail" do
       it { expect(true).to eq false }
-    end
-    """
+      end
+      """
     When I run `flatware rspec`
     Then the output contains the following:
-    """
-    F
-    """
+      """
+      F
+      """
     And the output contains the following:
-    """
-    1 example, 1 failure
-    """
+      """
+      1 example, 1 failure
+      """
     And the output contains the following lines:
-    """
-Failures:
+      """
+      Failures:
 
-  1) fail should eq false
-     Failure/Error: it { expect(true).to eq false }
+      1) fail should eq false
+      Failure/Error: it { expect(true).to eq false }
 
-       expected: false
-            got: true
+      expected: false
+      got: true
 
-       (compared using ==)
-     # ./spec/spec_spec.rb:2:in `block (2 levels) in <top (required)>'
-    """
+      (compared using ==)
+      """
+    And the output contains the following:
+      """
+      # ./spec/spec_spec.rb:2:in `block (2 levels) in <top (required)>'
+      """


### PR DESCRIPTION
RSpec added a bit about [diffs to the default output for bool comparisons](https://github.com/rspec/rspec-support/compare/v3.8.0...v3.8.2#diff-737358ce1dd8143b39a5660a93878afa).

This just skips asserting about that part of the output.