### PR TITLE
Do not crash on EINTR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
+# cache: bundler
+rvm:
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 before_install:
   - sudo apt-get install -qq libzmq3-dev
-rvm:
-  - 2.3.1

--- a/lib/flatware/poller.rb
+++ b/lib/flatware/poller.rb
@@ -9,7 +9,10 @@ module Flatware
 
     def each(&block)
       while (result = zmq_poller.poll) != 0
-        raise Error, ZMQ::Util.error_string, caller if result == -1
+        if result == -1
+          next if ZMQ::Util.errno == 4 # continue if poll returns EINTR
+          raise Error, ZMQ::Util.error_string, caller
+        end
         for socket in zmq_poller.readables.map &find_wrapped_socket
           yield socket
         end


### PR DESCRIPTION
This resolves the test (and runtime) failures for flatware under ruby 2.6.

Looking at other uses of zeromq (https://github.com/zeromq/erlzmq2/pull/67, https://grokbase.com/t/zeromq/zeromq-dev/1416wsc26h/zmq-poll-error#20140106y31s5ps9j4s9gpyqc67wnhpsgr), it seems like the best way to handle an EINTR is to continue polling.  

Resolves #51 
Related to #44 