### PR TITLE
Use serialized exception in execution result

### DIFF
--- a/lib/flatware/rspec.rb
+++ b/lib/flatware/rspec.rb
@@ -19,7 +19,9 @@ module Flatware
       runner = ::RSpec::Core::Runner
       def runner.trap_interrupt() end
 
+      profile_examples = ::RSpec.configuration.profile_examples
       ::RSpec.reset
+      ::RSpec.configuration.profile_examples = profile_examples
       ::RSpec.configuration.deprecation_stream = StringIO.new
       ::RSpec.configuration.output_stream = StringIO.new
       ::RSpec.configuration.add_formatter(Flatware::RSpec::Formatter)

--- a/lib/flatware/rspec/marshalable/example.rb
+++ b/lib/flatware/rspec/marshalable/example.rb
@@ -1,6 +1,7 @@
 module Flatware
   module RSpec
     module Marshalable
+      require 'flatware/rspec/marshalable/execution_result'
       require 'flatware/rspec/marshalable/shared_group_inclusion_backtrace'
 
       ##
@@ -14,7 +15,7 @@ module Flatware
         ]
       ) do
         def initialize(rspec_example)
-          super(*members.map do |attribute|
+          super(marshalable_execution_result(rspec_example.execution_result), *members[1..].map do |attribute|
             rspec_example.public_send(attribute)
           end)
 
@@ -24,6 +25,10 @@ module Flatware
         attr_reader :metadata
 
         private
+
+        def marshalable_execution_result(execution_result)
+          ExecutionResult.from_rspec(execution_result)
+        end
 
         def marshalable_metadata(rspec_metadata)
           rspec_metadata.slice(:extra_failure_lines).tap do |metadata|

--- a/lib/flatware/rspec/marshalable/execution_result.rb
+++ b/lib/flatware/rspec/marshalable/execution_result.rb
@@ -1,0 +1,18 @@
+module Flatware
+  module RSpec
+    module Marshalable
+      require 'flatware/serialized_exception'
+      class ExecutionResult < ::RSpec::Core::Example::ExecutionResult
+        def self.from_rspec(result)
+          new.tap do |marshalable|
+            marshalable.exception = result.exception && SerializedException.from(result.exception)
+
+            %i[finished_at run_time started_at status].each do |member|
+              marshalable.public_send(:"#{member}=", result.public_send(member))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/flatware/rspec/checkpoint_spec.rb
+++ b/spec/flatware/rspec/checkpoint_spec.rb
@@ -8,7 +8,7 @@ describe Flatware::RSpec::Checkpoint do
       failure_notification = instance_double(
         ::RSpec::Core::Example,
         full_description: 'bad news',
-        execution_result: nil,
+        execution_result: instance_double(::RSpec::Core::Example::ExecutionResult, exception: nil).as_null_object,
         location: nil,
         location_rerun_argument: nil,
         metadata: {}

--- a/spec/flatware/rspec/marshalable/example_spec.rb
+++ b/spec/flatware/rspec/marshalable/example_spec.rb
@@ -1,13 +1,25 @@
 require 'spec_helper'
 require 'flatware/rspec/marshalable/example'
 describe Flatware::RSpec::Marshalable::Example do
+  def stub_execution_result(exception)
+    instance_double(
+      ::RSpec::Core::Example::ExecutionResult,
+      exception: exception,
+      finished_at: Time.now,
+      run_time: 0,
+      started_at: Time.now,
+      status: :failed
+    )
+  end
+
   it 'caries what is needed to format a backtrace' do
+    exception = Exception.new
     ::RSpec::Core::Formatters::ExceptionPresenter.new(
-      Exception.new,
+      exception,
       described_class.new(
         instance_double(
           ::RSpec::Core::Example,
-          execution_result: nil,
+          execution_result: stub_execution_result(exception),
           full_description: nil,
           location: nil,
           location_rerun_argument: nil,
@@ -15,5 +27,22 @@ describe Flatware::RSpec::Marshalable::Example do
         )
       )
     ).fully_formatted(nil)
+  end
+
+  it 'does not cary constant references in exceptions' do
+    const = stub_const('A::Constant::Not::Likely::Loaded::In::Sink', Class.new(RuntimeError))
+    message = described_class.new(
+      instance_double(
+        ::RSpec::Core::Example,
+        execution_result: stub_execution_result(const.new),
+        full_description: nil,
+        location: nil,
+        location_rerun_argument: nil,
+        metadata: {}
+      )
+    )
+
+    expect(message.execution_result.exception.class.to_s).to eq(const.to_s)
+    expect(message.execution_result.exception.class).to_not be_an_instance_of(const)
   end
 end

--- a/spec/flatware/rspec/marshalable/examples_notification_spec.rb
+++ b/spec/flatware/rspec/marshalable/examples_notification_spec.rb
@@ -5,7 +5,7 @@ describe Flatware::RSpec::Marshalable::ExamplesNotification do
   it 'can be added together' do
     failed_example = instance_double(
       ::RSpec::Core::Example,
-      execution_result: nil,
+      execution_result: instance_double(::RSpec::Core::Example::ExecutionResult, exception: nil).as_null_object,
       full_description: 'the example',
       location_rerun_argument: nil,
       location: nil,


### PR DESCRIPTION
This resolves the known DRb marshaling problem form `render_views`.

resolves #56 