### PR TITLE
Fix/59 fail outside specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@
 # See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
 #
 AllCops:
+  TargetRubyVersion: 2.6
   Exclude:
     - tmp/**/*
     - vendor/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ gemspec name: 'flatware-rspec'
 gemspec name: 'flatware-cucumber'
 
 group :development do
-  gem 'appraisal'
+  gem 'appraisal', '~> 2.4'
   gem 'aruba', '~> 0.14'
-  gem 'pry'
-  gem 'rake'
-  gem 'rubocop', '~> 1.10.0'
-  gem 'rubocop-rake'
-  gem 'rubocop-rspec'
+  gem 'pry', '~> 0.14'
+  gem 'rake', '~> 13.0'
+  gem 'rubocop', '~> 1.11'
+  gem 'rubocop-rake', '~> 0.5'
+  gem 'rubocop-rspec', '~> 2.2'
 end

--- a/features/rspec.feature
+++ b/features/rspec.feature
@@ -83,3 +83,23 @@ Feature: rspec task
       """
       2 examples, 0 failures
       """
+
+  @non-zero
+  Scenario: failure outside of examples
+    Given the following spec:
+      """
+      throw :a_fit
+      describe 'fits' do
+        it('already threw one')
+      end
+      """
+    When I run flatware with "rspec"
+    Then the output contains the following line:
+      """
+      uncaught throw :a_fit
+      """
+
+    And the output contains the following line:
+      """
+      0 examples, 0 failures, 1 error occurred outside of examples
+      """

--- a/gemfiles/rspec_3.10.gemfile
+++ b/gemfiles/rspec_3.10.gemfile
@@ -5,13 +5,13 @@ source "https://rubygems.org"
 gem "rspec", "3.10.0"
 
 group :development do
-  gem "appraisal"
+  gem "appraisal", "~> 2.4"
   gem "aruba", "~> 0.14"
-  gem "pry"
-  gem "rake"
-  gem "rubocop", "~> 1.10.0"
-  gem "rubocop-rake"
-  gem "rubocop-rspec"
+  gem "pry", "~> 0.14"
+  gem "rake", "~> 13.0"
+  gem "rubocop", "~> 1.11"
+  gem "rubocop-rake", "~> 0.5"
+  gem "rubocop-rspec", "~> 2.2"
 end
 
 gemspec name: "flatware", path: "../"

--- a/gemfiles/rspec_3.10.gemfile.lock
+++ b/gemfiles/rspec_3.10.gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ..
   specs:
-    flatware (2.0.0.rc2)
+    flatware (2.0.0.rc3)
       thor (< 2.0)
-    flatware-cucumber (2.0.0.rc2)
+    flatware-cucumber (2.0.0.rc3)
       cucumber (~> 3.0)
-      flatware (= 2.0.0.rc2)
-    flatware-rspec (2.0.0.rc2)
-      flatware (= 2.0.0.rc2)
+      flatware (= 2.0.0.rc3)
+    flatware-rspec (2.0.0.rc3)
+      flatware (= 2.0.0.rc3)
       rspec (>= 3.6)
 
 GEM
@@ -47,7 +47,7 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.4.4)
-    ffi (1.14.2)
+    ffi (1.15.0)
     gherkin (5.1.0)
     method_source (1.0.0)
     multi_json (1.15.0)
@@ -75,7 +75,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.10.0)
+    rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -96,21 +96,22 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
-  appraisal
+  appraisal (~> 2.4)
   aruba (~> 0.14)
   flatware!
   flatware-cucumber!
   flatware-rspec!
-  pry
-  rake
+  pry (~> 0.14)
+  rake (~> 13.0)
   rspec (= 3.10.0)
-  rubocop (~> 1.10.0)
-  rubocop-rake
-  rubocop-rspec
+  rubocop (~> 1.11)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2.2)
 
 BUNDLED WITH
    2.2.3

--- a/gemfiles/rspec_3.6.gemfile
+++ b/gemfiles/rspec_3.6.gemfile
@@ -5,13 +5,13 @@ source "https://rubygems.org"
 gem "rspec", "3.6.0"
 
 group :development do
-  gem "appraisal"
+  gem "appraisal", "~> 2.4"
   gem "aruba", "~> 0.14"
-  gem "pry"
-  gem "rake"
-  gem "rubocop", "~> 1.10.0"
-  gem "rubocop-rake"
-  gem "rubocop-rspec"
+  gem "pry", "~> 0.14"
+  gem "rake", "~> 13.0"
+  gem "rubocop", "~> 1.11"
+  gem "rubocop-rake", "~> 0.5"
+  gem "rubocop-rspec", "~> 2.2"
 end
 
 gemspec name: "flatware", path: "../"

--- a/gemfiles/rspec_3.6.gemfile.lock
+++ b/gemfiles/rspec_3.6.gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ..
   specs:
-    flatware (2.0.0.rc2)
+    flatware (2.0.0.rc3)
       thor (< 2.0)
-    flatware-cucumber (2.0.0.rc2)
+    flatware-cucumber (2.0.0.rc3)
       cucumber (~> 3.0)
-      flatware (= 2.0.0.rc2)
-    flatware-rspec (2.0.0.rc2)
-      flatware (= 2.0.0.rc2)
+      flatware (= 2.0.0.rc3)
+    flatware-rspec (2.0.0.rc3)
+      flatware (= 2.0.0.rc3)
       rspec (>= 3.6)
 
 GEM
@@ -47,7 +47,7 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.4.4)
-    ffi (1.14.2)
+    ffi (1.15.0)
     gherkin (5.1.0)
     method_source (1.0.0)
     multi_json (1.15.0)
@@ -75,7 +75,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubocop (1.10.0)
+    rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -96,21 +96,22 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
-  appraisal
+  appraisal (~> 2.4)
   aruba (~> 0.14)
   flatware!
   flatware-cucumber!
   flatware-rspec!
-  pry
-  rake
+  pry (~> 0.14)
+  rake (~> 13.0)
   rspec (= 3.6.0)
-  rubocop (~> 1.10.0)
-  rubocop-rake
-  rubocop-rspec
+  rubocop (~> 1.11)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2.2)
 
 BUNDLED WITH
    2.2.3

--- a/gemfiles/rspec_3.7.gemfile
+++ b/gemfiles/rspec_3.7.gemfile
@@ -5,13 +5,13 @@ source "https://rubygems.org"
 gem "rspec", "3.7.0"
 
 group :development do
-  gem "appraisal"
+  gem "appraisal", "~> 2.4"
   gem "aruba", "~> 0.14"
-  gem "pry"
-  gem "rake"
-  gem "rubocop", "~> 1.10.0"
-  gem "rubocop-rake"
-  gem "rubocop-rspec"
+  gem "pry", "~> 0.14"
+  gem "rake", "~> 13.0"
+  gem "rubocop", "~> 1.11"
+  gem "rubocop-rake", "~> 0.5"
+  gem "rubocop-rspec", "~> 2.2"
 end
 
 gemspec name: "flatware", path: "../"

--- a/gemfiles/rspec_3.7.gemfile.lock
+++ b/gemfiles/rspec_3.7.gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ..
   specs:
-    flatware (2.0.0.rc2)
+    flatware (2.0.0.rc3)
       thor (< 2.0)
-    flatware-cucumber (2.0.0.rc2)
+    flatware-cucumber (2.0.0.rc3)
       cucumber (~> 3.0)
-      flatware (= 2.0.0.rc2)
-    flatware-rspec (2.0.0.rc2)
-      flatware (= 2.0.0.rc2)
+      flatware (= 2.0.0.rc3)
+    flatware-rspec (2.0.0.rc3)
+      flatware (= 2.0.0.rc3)
       rspec (>= 3.6)
 
 GEM
@@ -47,7 +47,7 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.4.4)
-    ffi (1.14.2)
+    ffi (1.15.0)
     gherkin (5.1.0)
     method_source (1.0.0)
     multi_json (1.15.0)
@@ -75,7 +75,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (1.10.0)
+    rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -96,21 +96,22 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
-  appraisal
+  appraisal (~> 2.4)
   aruba (~> 0.14)
   flatware!
   flatware-cucumber!
   flatware-rspec!
-  pry
-  rake
+  pry (~> 0.14)
+  rake (~> 13.0)
   rspec (= 3.7.0)
-  rubocop (~> 1.10.0)
-  rubocop-rake
-  rubocop-rspec
+  rubocop (~> 1.11)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2.2)
 
 BUNDLED WITH
    2.2.3

--- a/gemfiles/rspec_3.8.gemfile
+++ b/gemfiles/rspec_3.8.gemfile
@@ -5,13 +5,13 @@ source "https://rubygems.org"
 gem "rspec", "3.8.0"
 
 group :development do
-  gem "appraisal"
+  gem "appraisal", "~> 2.4"
   gem "aruba", "~> 0.14"
-  gem "pry"
-  gem "rake"
-  gem "rubocop", "~> 1.10.0"
-  gem "rubocop-rake"
-  gem "rubocop-rspec"
+  gem "pry", "~> 0.14"
+  gem "rake", "~> 13.0"
+  gem "rubocop", "~> 1.11"
+  gem "rubocop-rake", "~> 0.5"
+  gem "rubocop-rspec", "~> 2.2"
 end
 
 gemspec name: "flatware", path: "../"

--- a/gemfiles/rspec_3.8.gemfile.lock
+++ b/gemfiles/rspec_3.8.gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ..
   specs:
-    flatware (2.0.0.rc2)
+    flatware (2.0.0.rc3)
       thor (< 2.0)
-    flatware-cucumber (2.0.0.rc2)
+    flatware-cucumber (2.0.0.rc3)
       cucumber (~> 3.0)
-      flatware (= 2.0.0.rc2)
-    flatware-rspec (2.0.0.rc2)
-      flatware (= 2.0.0.rc2)
+      flatware (= 2.0.0.rc3)
+    flatware-rspec (2.0.0.rc3)
+      flatware (= 2.0.0.rc3)
       rspec (>= 3.6)
 
 GEM
@@ -47,7 +47,7 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.4.4)
-    ffi (1.14.2)
+    ffi (1.15.0)
     gherkin (5.1.0)
     method_source (1.0.0)
     multi_json (1.15.0)
@@ -75,7 +75,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.3)
-    rubocop (1.10.0)
+    rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -96,21 +96,22 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
-  appraisal
+  appraisal (~> 2.4)
   aruba (~> 0.14)
   flatware!
   flatware-cucumber!
   flatware-rspec!
-  pry
-  rake
+  pry (~> 0.14)
+  rake (~> 13.0)
   rspec (= 3.8.0)
-  rubocop (~> 1.10.0)
-  rubocop-rake
-  rubocop-rspec
+  rubocop (~> 1.11)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2.2)
 
 BUNDLED WITH
    2.2.3

--- a/gemfiles/rspec_3.9.gemfile
+++ b/gemfiles/rspec_3.9.gemfile
@@ -5,13 +5,13 @@ source "https://rubygems.org"
 gem "rspec", "3.9.0"
 
 group :development do
-  gem "appraisal"
+  gem "appraisal", "~> 2.4"
   gem "aruba", "~> 0.14"
-  gem "pry"
-  gem "rake"
-  gem "rubocop", "~> 1.10.0"
-  gem "rubocop-rake"
-  gem "rubocop-rspec"
+  gem "pry", "~> 0.14"
+  gem "rake", "~> 13.0"
+  gem "rubocop", "~> 1.11"
+  gem "rubocop-rake", "~> 0.5"
+  gem "rubocop-rspec", "~> 2.2"
 end
 
 gemspec name: "flatware", path: "../"

--- a/gemfiles/rspec_3.9.gemfile.lock
+++ b/gemfiles/rspec_3.9.gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ..
   specs:
-    flatware (2.0.0.rc2)
+    flatware (2.0.0.rc3)
       thor (< 2.0)
-    flatware-cucumber (2.0.0.rc2)
+    flatware-cucumber (2.0.0.rc3)
       cucumber (~> 3.0)
-      flatware (= 2.0.0.rc2)
-    flatware-rspec (2.0.0.rc2)
-      flatware (= 2.0.0.rc2)
+      flatware (= 2.0.0.rc3)
+    flatware-rspec (2.0.0.rc3)
+      flatware (= 2.0.0.rc3)
       rspec (>= 3.6)
 
 GEM
@@ -47,7 +47,7 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.4.4)
-    ffi (1.14.2)
+    ffi (1.15.0)
     gherkin (5.1.0)
     method_source (1.0.0)
     multi_json (1.15.0)
@@ -68,14 +68,14 @@ GEM
       rspec-mocks (~> 3.9.0)
     rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.3)
+    rspec-expectations (3.9.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.4)
-    rubocop (1.10.0)
+    rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -96,21 +96,22 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
-  appraisal
+  appraisal (~> 2.4)
   aruba (~> 0.14)
   flatware!
   flatware-cucumber!
   flatware-rspec!
-  pry
-  rake
+  pry (~> 0.14)
+  rake (~> 13.0)
   rspec (= 3.9.0)
-  rubocop (~> 1.10.0)
-  rubocop-rake
-  rubocop-rspec
+  rubocop (~> 1.11)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2.2)
 
 BUNDLED WITH
    2.2.3

--- a/lib/flatware/broadcaster.rb
+++ b/lib/flatware/broadcaster.rb
@@ -4,10 +4,11 @@ module Flatware
   # sends messages to all formatters
   class Broadcaster
     FORMATTER_MESSAGES = %i[
-      jobs
-      started
-      progress
       finished
+      jobs
+      message
+      progress
+      started
       summarize
       summarize_remaining
     ].freeze

--- a/lib/flatware/rspec.rb
+++ b/lib/flatware/rspec.rb
@@ -21,9 +21,17 @@ module Flatware
       end
     end
 
+    def output_stream
+      StringIO.new.tap do |output|
+        output.define_singleton_method(:tty?) do
+          $stdout.tty?
+        end
+      end
+    end
+
     def run(job, _options = [])
       ::RSpec.configuration.deprecation_stream = StringIO.new
-      ::RSpec.configuration.output_stream = StringIO.new
+      ::RSpec.configuration.output_stream = output_stream
       ::RSpec.configuration.add_formatter(Flatware::RSpec::Formatter)
 
       runner.run(Array(job), $stderr, $stdout)

--- a/lib/flatware/rspec/formatter.rb
+++ b/lib/flatware/rspec/formatter.rb
@@ -29,6 +29,10 @@ module Flatware
         send_progress :pending
       end
 
+      def message(message)
+        Sink.client.message message
+      end
+
       def close(*)
         Sink.client.checkpoint checkpoint
         @checkpoint = nil
@@ -50,6 +54,7 @@ module Flatware
         :example_passed,
         :example_failed,
         :example_pending,
+        :message,
         :close
       )
     end

--- a/lib/flatware/rspec/formatters/console.rb
+++ b/lib/flatware/rspec/formatters/console.rb
@@ -17,6 +17,10 @@ module Flatware
           progress_formatter.public_send(message_for(result), nil)
         end
 
+        def message(message)
+          out.puts(message.message)
+        end
+
         def summarize(checkpoints)
           return if checkpoints.empty?
 

--- a/lib/flatware/sink/client.rb
+++ b/lib/flatware/sink/client.rb
@@ -11,7 +11,7 @@ module Flatware
         @sink = DRbObject.new_with_uri sink_endpoint
       end
 
-      %w[ready finished started progress checkpoint].each do |message|
+      %w[ready finished started progress message checkpoint].each do |message|
         define_method message do |content|
           push [message.to_sym, content]
         end


### PR DESCRIPTION
Send `:message` messages to the formatter since they cary backtraces from outside examples

Fixes #59 