### PR TITLE
CI: Use bundler-cache from setup-ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,8 @@ jobs:
       matrix:
         gemfile: [6,7,8,9,10]
         ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
-
+    env:
+      BUNDLE_GEMFILE: gemfiles/rspec_3.${{matrix.gemfile}}.gemfile
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -30,9 +31,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: install bundle
-      env:
-        BUNDLE_GEMFILE: gemfiles/rspec_3.${{matrix.gemfile}}.gemfile
-      run: bundle install
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
See https://github.com/ruby/setup-ruby#matrix-of-gemfiles for a note on how to let the "env" directive work for all of the matrix, without an extra step.