### PR TITLE
Fix DRbUnknown error with unserializable Exception causes

### DIFF
--- a/lib/flatware/serialized_exception.rb
+++ b/lib/flatware/serialized_exception.rb
@@ -3,11 +3,11 @@ module Flatware
     attr_reader :class, :message, :cause
     attr_accessor :backtrace
 
-    def initialize(klass, message, backtrace, cause = '')
+    def initialize(klass, message, backtrace, cause = nil)
       @class = serialized(klass)
       @message = message
       @backtrace = backtrace
-      @cause = cause
+      @cause = cause && SerializedException.from(cause)
     end
 
     def self.from(exception)

--- a/spec/flatware/rspec/marshalable/example_spec.rb
+++ b/spec/flatware/rspec/marshalable/example_spec.rb
@@ -12,7 +12,7 @@ describe Flatware::RSpec::Marshalable::Example do
     )
   end
 
-  it 'caries what is needed to format a backtrace' do
+  it 'carries what is needed to format a backtrace' do
     exception = Exception.new
     RSpec::Core::Formatters::ExceptionPresenter.new(
       exception,
@@ -29,12 +29,24 @@ describe Flatware::RSpec::Marshalable::Example do
     ).fully_formatted(nil)
   end
 
-  it 'does not cary constant references in exceptions' do
+  it 'does not carry constant references in exceptions' do
     const = stub_const('A::Constant::Not::Likely::Loaded::In::Sink', Class.new(RuntimeError))
+    wrapper_const = stub_const('Another::Constant::Not::Likely::Loaded::In::Sink', Class.new(RuntimeError))
+    caught_exception = begin
+      begin
+        raise const, 'something bad happened'
+      rescue RuntimeError => e
+        # raise a second exception so that Exception#cause is set up
+        raise wrapper_const, e
+      end
+    rescue RuntimeError => e
+      e
+    end
+
     message = described_class.new(
       instance_double(
         RSpec::Core::Example,
-        execution_result: stub_execution_result(const.new),
+        execution_result: stub_execution_result(caught_exception),
         full_description: nil,
         location: nil,
         location_rerun_argument: nil,
@@ -42,7 +54,14 @@ describe Flatware::RSpec::Marshalable::Example do
       )
     )
 
-    expect(message.execution_result.exception.class.to_s).to eq(const.to_s)
-    expect(message.execution_result.exception.class).to_not be_an_instance_of(const)
+    result_exception = message.execution_result.exception
+
+    expect(result_exception).to be_an_instance_of(Flatware::SerializedException)
+    expect(result_exception.class.to_s).to eq(wrapper_const.to_s)
+    expect(result_exception.class).to_not be_an_instance_of(wrapper_const)
+
+    expect(result_exception.cause).to be_an_instance_of(Flatware::SerializedException)
+    expect(result_exception.cause.class.to_s).to eq(const.to_s)
+    expect(result_exception.cause.class).to_not be_an_instance_of(const)
   end
 end


### PR DESCRIPTION
I ran into this when an error was raised in a view template, so got wrapped in ActionView::TemplateError. ActionView::TemplateError was correctly serialised, but its `cause` still referenced classes that don't exist in the sink, resulting in errors like this:

```
flatware-rspec-2.2.0/lib/flatware/rspec/formatters/console.rb:29:in `summarize': undefined method `pending_examples' for
#<DRb::DRbUnknown:0x0000000105f7c6b8 @name="User", @buf="\x04\bo: 
Flatware::RSpec::Checkpoint\x06:\f@events{\t:\x10deprecation[\x00:\x11
dump_pendingo:7Flatware::RSpec::Marshalable::ExamplesNotification\x06:\x0E
@reporterS:AFlatware::RSpec::Marshalable::ExamplesNotification::Reporter\b:\rexamples[\x
```

Maybe something like this to fix it?