### PR TITLE
Continue even if Process.setpgrp fails

### DIFF
--- a/lib/flatware/cli.rb
+++ b/lib/flatware/cli.rb
@@ -55,7 +55,8 @@ module Flatware
 
     def start_sink(jobs:, workers:, formatter:)
       $0 = 'flatware sink'
-      Process.setpgrp
+      try_setpgrp
+
       passed = Sink.start_server(
         jobs: jobs,
         formatter: Flatware::Broadcaster.new([formatter]),
@@ -63,6 +64,12 @@ module Flatware
         worker_count: workers
       )
       exit passed ? 0 : 1
+    end
+
+    def try_setpgrp
+      Process.setpgrp
+    rescue Errno::EPERM => e
+      Flatware.log 'continuing after: Process.setpgrp:', e.message
     end
 
     def workers


### PR DESCRIPTION
In CircleCI, calling `Process.setpgrp` raises an "Operation not permitted" error,
but other than that flatware works.

In this proposed change, we allow flatware to continue when the error is raised. Resolves #66.

If flatware is executed with --log, then it will print:
`INFO -- : flatware sink continuing after: Process.setpgrp: Operation not permitted`

At Carwow, we have been running flatware on CircleCI for about 1 month (with a monkey-patched Process.setpgrp), on multiple large (5k+ tests) projects, and it works great! It allowed Carwow to reduce CircleCI credits by half, and also our Docker Hub pulls (which you have to pay if doing more than 5k/day).

Example CircleCI run (flatware running flatware tests): 
https://app.circleci.com/pipelines/github/PChambino/flatware/18/workflows/9ae4f8b6-65c2-4ae7-af56-ece266bc69e1/jobs/33
(The relevant log line is the first line. The process fails, but the rspec report shows no failures. There is a log line about rspec-mocks, but it is unrelated to the change or CircleCI. This is just to demonstrate the setpgrp log.)