### PR TITLE
Fix tests hanging when a worker dies unexpectedly due to an unrecoverable error such as a segfault

### DIFF
--- a/lib/flatware.rb
+++ b/lib/flatware.rb
@@ -7,6 +7,7 @@ module Flatware
   require 'flatware/cli'
   require 'flatware/sink'
   require 'flatware/worker'
+  require 'flatware/worker_manager'
   require 'flatware/broadcaster'
 
   module_function

--- a/lib/flatware/cli.rb
+++ b/lib/flatware/cli.rb
@@ -53,7 +53,7 @@ module Flatware
 
     private
 
-    def start_sink(jobs:, workers:, formatter:)
+    def start_sink(jobs:, worker_manager:, formatter:)
       $0 = 'flatware sink'
       try_setpgrp
 
@@ -61,7 +61,7 @@ module Flatware
         jobs: jobs,
         formatter: Flatware::Broadcaster.new([formatter]),
         sink: options['sink-endpoint'],
-        worker_count: workers
+        worker_manager: worker_manager
       )
       exit passed ? 0 : 1
     end

--- a/lib/flatware/cucumber/cli.rb
+++ b/lib/flatware/cucumber/cli.rb
@@ -22,10 +22,10 @@ module Flatware
 
       Flatware.verbose = options[:log]
       sink = options['sink-endpoint']
-      Worker.spawn(count: workers, runner: Cucumber, sink: sink)
+      worker_manager = WorkerManager.new(count: workers, runner: Cucumber, sink: sink)
       start_sink(
         jobs: config.jobs,
-        workers: workers,
+        worker_manager: worker_manager,
         formatter: Flatware::Cucumber::Formatters::Console.new($stdout, $stderr)
       )
     end

--- a/lib/flatware/rspec/cli.rb
+++ b/lib/flatware/rspec/cli.rb
@@ -23,8 +23,8 @@ module Flatware
       )
 
       Flatware.verbose = options[:log]
-      Worker.spawn count: workers, runner: RSpec, sink: options['sink-endpoint']
-      start_sink(jobs: jobs, workers: workers, formatter: formatter)
+      worker_manager = WorkerManager.new(count: workers, runner: RSpec, sink: options['sink-endpoint'])
+      start_sink(jobs: jobs, worker_manager: worker_manager, formatter: formatter)
     end
   end
 end

--- a/lib/flatware/worker.rb
+++ b/lib/flatware/worker.rb
@@ -15,18 +15,6 @@ module Flatware
       Flatware::Sink.client = @sink
     end
 
-    def self.spawn(count:, runner:, sink:, **)
-      Flatware.configuration.before_fork.call
-      count.times do |i|
-        fork do
-          $0 = "flatware worker #{i}"
-          ENV['TEST_ENV_NUMBER'] = i.to_s
-          Flatware.configuration.after_fork.call(i)
-          new(i, runner, sink).listen
-        end
-      end
-    end
-
     def listen
       retrying(times: 10, wait: 0.1) do
         job = sink.ready id

--- a/lib/flatware/worker_manager.rb
+++ b/lib/flatware/worker_manager.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Flatware
+  # Manages the available workers to execute tests on
+  class WorkerManager
+    attr_reader :sink, :runner, :id
+
+    attr_reader :workers
+
+    def initialize(count:, runner:, sink:)
+      @runner = runner
+      @sink = sink
+      @stopped = false
+
+      @workers = Set.new
+      @worker_pids = {}
+      count.times do |i|
+        register(i)
+      end
+    end
+
+    def stop
+      @stopped = true
+    end
+
+    def spawn
+      Flatware.configuration.before_fork.call
+      trap_signals
+      respawn
+    end
+
+    def respawn
+      worker_ids = @workers - @worker_pids.keys
+      worker_ids.each do |id|
+        pid = fork do
+          DRb.stop_service
+          $0 = "flatware worker #{id}"
+          ENV['TEST_ENV_NUMBER'] = id.to_s
+          Flatware.configuration.after_fork.call(id)
+          Worker.new(id, @runner, @sink).listen
+        end
+
+        @worker_pids[id] = pid
+      end
+    end
+
+    def register(worker_id)
+      @workers << worker_id
+    end
+
+    def delete(worker_id)
+      @workers.delete(worker_id)
+    end
+
+    def count
+      @workers.length
+    end
+
+    def trap_signals
+      Thread.main[:child_signals] = Queue.new
+
+      Thread.new(&method(:handle_signals))
+
+      trap 'CHLD' do
+        if Thread.main[:child_signals]
+          Thread.main[:child_signals] << :chld
+        end
+      end
+    end
+
+    def handle_signals
+      while !@stopped
+        Thread.main[:child_signals].pop
+        reap_workers
+        respawn unless @stopped
+      end
+    end
+
+    def reap_workers
+      @worker_pids.reject! do |id, pid|
+        # Non-blocking wait for process to die
+        begin
+          status = Process.wait(pid, Process::WNOHANG)
+          case status
+          when nil
+            # Process is still running
+            false
+          when pid
+            # Collected status of this pid
+            true
+          end
+        rescue Errno::ECHILD
+          # Child process has already terminated
+          true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes flatware hanging indefinitely when a worker dues unexpectedly due to an unrecoverable error such as a segmentation fault.

## Context

When a worker dies unexpectedly, currently flatware has no `CHLD` signal handling in place to catch the death of that process and recover.  This can happen if your spec happens to trigger a segmentation fault.  In our specs, this happens rarely and randomly, but when it does -- it causes our CI to sit there waiting forever.

## Solution

The proposed solution is to introduce a class that's responsible for "managing" workers.  Specifically, this class will listen for `CHLD` signals and re-spawn a worker if the process was killed unexpectedly.

We can define "unexpected" based on whether the sink proactively deleted the worker when returning `Job.sentinel`.

Additionally, when the worker is re-spawned, we re-assign it the same work that it was previously assigned.

## Alternative Solutions

Possible alternative solutions:

* Don't retry specs when a worker dies unexpectedly but make sure that flatware is aware of this situation and eventually returns a non-zero error code

## Open Questions

* [ ] Is this a reasonable path forward to address this issue?
* [ ] What, if anything, should we do for unrecoverable exceptions that are caused consistently (e.g. if a spec *always* causes a segmentation fault)?  Should there be a maximum number of retries?
* [ ] Are there other scenarios I haven't accounted for?

## TODO

Assuming moving forward with the approach:

* [ ] Update specs

Looking for any feedback on the high-level approach before updating the specs.  Thanks!