### PR TITLE
Fix: Use max for duration and load_time in SummaryNotification

### DIFF
--- a/lib/flatware/rspec/marshalable/summary_notification.rb
+++ b/lib/flatware/rspec/marshalable/summary_notification.rb
@@ -6,7 +6,15 @@ module Flatware
     module Marshalable
       class SummaryNotification < ::RSpec::Core::Notifications::SummaryNotification
         def +(other)
-          self.class.new(*zip(other).map { |a, b| a + b })
+          values = to_h.map do |key, value|
+            if %i[duration load_time].include?(key)
+              [value, other.public_send(key)].max
+            else
+              value + other.public_send(key)
+            end
+          end
+
+          self.class.new(*values)
         end
 
         def failures?

--- a/spec/flatware/rspec/marshalable/summary_notification_spec.rb
+++ b/spec/flatware/rspec/marshalable/summary_notification_spec.rb
@@ -2,19 +2,28 @@ require 'spec_helper'
 require 'flatware/rspec/marshalable/summary_notification'
 
 describe Flatware::RSpec::Marshalable::SummaryNotification do
-  def args
-    [1, [], [], []] + (5..described_class.members.size).to_a
-  end
+  let(:args1) { [1, [], [], [], 0.2, 6] }
+  let(:args2) { [2, [], [], [], 0.3, 6] }
 
-  it 'can be added together' do
-    summary1 = described_class.new(*args)
-    summary2 = described_class.new(*args)
+  it 'can be added together (duration and load_time handled with #max)' do
+    expected_result = {
+      duration: 2,
+      examples: [],
+      failed_examples: [],
+      pending_examples: [],
+      load_time: 0.3,
+      errors_outside_of_examples_count: 12
+    }
+
+    summary1 = described_class.new(*args1)
+    summary2 = described_class.new(*args2)
     result = summary1 + summary2
-    expect(result.to_a).to eq(args.map { |x| x * 2 })
+
+    expect(result.to_h).to eq(expected_result)
   end
 
   it 'plays nice with the rspec formatting stuff' do
-    notification = RSpec::Core::Notifications::SummaryNotification.new(*args)
+    notification = RSpec::Core::Notifications::SummaryNotification.new(*args1)
     summary = described_class.from_rspec(notification)
     expect(summary.fully_formatted).to match(/Finished/)
   end


### PR DESCRIPTION
Hey, I just discovered this gem and was playing around with it this weekend and I love it. Found a small issue though with times measured so here's a fix :) 

### Context
In SummaryNotification, all the values were added. While this is good for example arrays and `errors_outside_of_examples_count`, for `duration` and `load_time` this does not make much sense and times measured were unrealistic.

### Solution
I have opted for `max` value of the two attributes.

Before:
<img width="550" alt="image" src="https://github.com/briandunn/flatware/assets/1552105/b0da3eb3-7eba-4420-a230-461562328f62">

After:
<img width="490" alt="image" src="https://github.com/briandunn/flatware/assets/1552105/59cb653c-c561-43ec-ab16-d5d28723726c">
