### PR TITLE
Introduce the duration provider pattern

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,8 @@ Naming/FileName:
     - lib/flatware-*.rb
 Style/Documentation:
   Enabled: false
+Metrics/AbcSize:
+  Max: 20
 Metrics/BlockLength:
   Exclude:
     - spec/**/*_spec.rb

--- a/lib/flatware/rspec.rb
+++ b/lib/flatware/rspec.rb
@@ -11,8 +11,8 @@ module Flatware
 
     module_function
 
-    def extract_jobs_from_args(args, workers:)
-      JobBuilder.new(args, workers: workers).jobs
+    def extract_jobs_from_args(args, workers:, duration_provider:)
+      JobBuilder.new(args, workers: workers, duration_provider: duration_provider).jobs
     end
 
     def runner

--- a/lib/flatware/rspec/cli.rb
+++ b/lib/flatware/rspec/cli.rb
@@ -2,10 +2,10 @@
 
 require 'flatware/cli'
 require 'flatware/rspec'
+require 'flatware/rspec/duration_providers'
 require 'flatware/rspec/formatters/console'
 
 module Flatware
-  # rspec thor command
   class CLI
     worker_option
     method_option(
@@ -13,9 +13,17 @@ module Flatware
       type: :string,
       default: 'drbunix:flatware-sink'
     )
+    method_option(
+      :'duration-provider',
+      aliases: '-d',
+      type: :string,
+      default: :example_statuses,
+      desc: 'Duration provider to use. The default option is "example_statuses".'
+    )
     desc 'rspec [FLATWARE_OPTS]', 'parallelizes rspec'
     def rspec(*rspec_args)
-      jobs = RSpec.extract_jobs_from_args rspec_args, workers: workers
+      duration_provider = RSpec::DurationProviders.lookup(options['duration-provider'])
+      jobs = RSpec.extract_jobs_from_args rspec_args, workers: workers, duration_provider: duration_provider
 
       formatter = Flatware::RSpec::Formatters::Console.new(
         ::RSpec.configuration.output_stream,

--- a/lib/flatware/rspec/duration_providers.rb
+++ b/lib/flatware/rspec/duration_providers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'flatware/rspec/duration_providers/example_statuses_provider'
+
+module Flatware
+  module RSpec
+    module DurationProviders
+      module_function
+
+      def lookup(provider)
+        const_get("#{classify(provider)}Provider").new
+      end
+
+      def classify(underscore_name)
+        underscore_name.to_s.split('_').map(&:capitalize).join
+      end
+
+      private_class_method :classify
+    end
+  end
+end

--- a/lib/flatware/rspec/duration_providers/example_statuses_provider.rb
+++ b/lib/flatware/rspec/duration_providers/example_statuses_provider.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Flatware
+  module RSpec
+    module DurationProviders
+      class ExampleStatusesProvider
+        extend Forwardable
+        attr_reader :configuration
+
+        def_delegators :configuration, :example_status_persistence_file_path
+
+        def initialize(configuration: ::RSpec.configuration)
+          @configuration = configuration
+        end
+
+        def seconds_per_file
+          sum_seconds(load_persisted_example_statuses)
+        end
+
+        private
+
+        def load_persisted_example_statuses
+          ::RSpec::Core::ExampleStatusPersister.load_from(
+            example_status_persistence_file_path || ''
+          )
+        end
+
+        def sum_seconds(statuses)
+          statuses.select(&passing)
+                  .map { |example| parse_example(**example) }
+                  .reduce({}) do |times, example|
+            times.merge(
+              example.fetch(:file_name) => example.fetch(:seconds)
+            ) do |_, old = 0, new|
+              old + new
+            end
+          end
+        end
+
+        def passing
+          ->(example) { example.fetch(:status) =~ /pass/i }
+        end
+
+        def parse_example(example_id:, run_time:, **)
+          seconds = run_time.match(/\d+(\.\d+)?/).to_s.to_f
+          file_name = ::RSpec::Core::Example.parse_id(example_id).first
+          { seconds: seconds, file_name: file_name }
+        end
+      end
+    end
+  end
+end

--- a/spec/flatware/rspec/duration_providers/example_statuses_provider_spec.rb
+++ b/spec/flatware/rspec/duration_providers/example_statuses_provider_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'flatware/rspec/duration_providers/example_statuses_provider'
+
+describe Flatware::RSpec::DurationProviders::ExampleStatusesProvider do
+  before do
+    allow(RSpec::Core::ExampleStatusPersister).to(
+      receive(:load_from).and_return(persisted_examples)
+    )
+  end
+
+  let(:persisted_examples) do
+    [
+      { example_id: './fast_1_spec.rb[1]', run_time: '1 second' },
+      { example_id: './fast_2_spec.rb[1]', run_time: '1 second' },
+      { example_id: './fast_3_spec.rb[1]', run_time: '1 second' },
+      { example_id: './slow_spec.rb[1]', run_time: '2 seconds' }
+    ].map { |example| example.merge status: 'passed' }
+  end
+
+  describe '#seconds_per_file' do
+    subject { described_class.new.seconds_per_file }
+
+    it 'returns an object of the specified provider class' do
+      expect(subject).to eq(
+        './fast_1_spec.rb' => 1.0,
+        './fast_2_spec.rb' => 1.0,
+        './fast_3_spec.rb' => 1.0,
+        './slow_spec.rb' => 2.0
+      )
+    end
+  end
+end

--- a/spec/flatware/rspec/duration_providers_spec.rb
+++ b/spec/flatware/rspec/duration_providers_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'flatware/rspec/duration_providers'
+
+describe Flatware::RSpec::DurationProviders do
+  describe '#lookup' do
+    before do
+      Flatware::RSpec::DurationProviders.const_set(:MockProvider, mock_provider)
+    end
+
+    after do
+      Flatware::RSpec::DurationProviders.send(:remove_const, :MockProvider)
+    end
+
+    let(:mock_provider) { Class.new }
+
+    it 'returns an object of the specified provider class' do
+      expect(described_class.lookup('mock')).to be_a(mock_provider)
+    end
+
+    it 'works with a string argument' do
+      expect(described_class.lookup(:mock)).to be_a(mock_provider)
+    end
+  end
+end

--- a/spec/flatware/rspec/job_builder_spec.rb
+++ b/spec/flatware/rspec/job_builder_spec.rb
@@ -5,30 +5,27 @@ require 'flatware/rspec/job_builder'
 
 describe Flatware::RSpec::JobBuilder do
   before do
-    allow(RSpec::Core::ExampleStatusPersister).to(
-      receive(:load_from).and_return(persisted_examples)
-    )
-
     allow(RSpec.configuration).to(
       receive(:files_to_run).and_return(files_to_run)
     )
   end
 
-  let(:persisted_examples) { [] }
+  let(:duration_provider) { double('duration_provider', seconds_per_file: seconds_per_file) }
+  let(:seconds_per_file) { [] }
   let(:files_to_run) { [] }
 
   subject do
-    described_class.new([], workers: 2).jobs
+    described_class.new([], workers: 2, duration_provider: duration_provider).jobs
   end
 
   context 'when this run includes persisted examples' do
-    let(:persisted_examples) do
-      [
-        { example_id: './fast_1_spec.rb[1]', run_time: '1 second' },
-        { example_id: './fast_2_spec.rb[1]', run_time: '1 second' },
-        { example_id: './fast_3_spec.rb[1]', run_time: '1 second' },
-        { example_id: './slow_spec.rb[1]', run_time: '2 seconds' }
-      ].map { |example| example.merge status: 'passed' }
+    let(:seconds_per_file) do
+      {
+        './fast_1_spec.rb' => 1.0,
+        './fast_2_spec.rb' => 1.0,
+        './fast_3_spec.rb' => 1.0,
+        './slow_spec.rb' => 2.0
+      }
     end
 
     let(:files_to_run) { %w[fast_1_spec.rb fast_2_spec.rb slow_spec.rb] }


### PR DESCRIPTION
First off, thanks so much for crafting such a fantastic gem! I’m a big fan of how `flatware` handles the forking and dRuby communication—it really makes a difference.

Background
We’ve started using flatware in one of our projects and hit a snag with the RSpec example status persistence file. It got massive—over 500MB, due to the existence of more than 80,000 examples—and it was slowing down our tests almost more than just running them!

We tried a workaround with [`parallel_tests`](https://github.com/grosser/parallel_tests?tab=readme-ov-file#even-test-group-runtimes)' `ParallelTests::RSpec::RuntimeLogger`, which trimmed the data down to just 500KB (mostly because it only tracks the execution time for each file, rather than for each example.) We also had to monky-patch the `JobBuilder` a bit to make it work, but it felt a bit like a hack and might be a pain to maintain.

## What This PR is about

So, I'm proposing a new "Duration Provider" pattern in this pull request. It would let us and other users customize how duration calculations are done without messing too much with `JobBuilder`. This should make things more flexible and cleaner overall.

Here’s a peek at the custom provider we whipped up:

```ruby
# lib/flatware/rspec/duration_providers/parallel_tests_runtime_provider.rb
module Flatware
  module RSpec
    module DurationProviders
      class ParallelTestsRuntimeProvider
        attr_reader :test_runtime_file

        def initialize(test_runtime_file: ENV.fetch('TEST_RUNTIME'))
          @test_runtime_file = test_runtime_file
        end

        def seconds_per_file
          @seconds_per_file ||= # Load the parallel tests runtime file here...
      end
    end
  end
end
```

We then use this command to run the tests:

```shell
$ # The bin/flatware file is also our own executable that `require`s the provider above:
$ bin/flatware rspec -d parallel_tests_runtime ...
```

I think this could really streamline how we manage custom durations and keep things neat. Let me know what you all think.

/cc @zzak @kei-s