### PR TITLE
fan: exit with non-zero status on failure

### DIFF
--- a/lib/flatware/cli.rb
+++ b/lib/flatware/cli.rb
@@ -41,7 +41,8 @@ module Flatware
           exec({ 'TEST_ENV_NUMBER' => i.to_s }, command)
         end
       end
-      Process.waitall
+      success = Process.waitall.all? { |_pid, status| status.success? }
+      exit success ? 0 : 1
     end
 
     desc 'clear', 'kills all flatware processes'


### PR DESCRIPTION
Currently if a `fan` worker fails, fan still exits successfully, which can hide errors. How about exiting with 1 if any of them fail?