### PR TITLE
Add drb to gemspec

### DIFF
--- a/flatware.gemspec
+++ b/flatware.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ['>= 2.6', '< 3.4']
   s.require_paths = ['lib']
   s.executables = ['flatware']
+  s.add_dependency %(drb)
   s.add_dependency %(thor), '< 2.0'
   # s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
When running `flatware` on ruby 3.3.x, we get a warning that `drb` will be removed from the stdlib starting in 3.4.0 and to contact the author of flatware to add it to the gemspec. Figured I could do one better and add it myself 😄.

```
% bundle exec rake spec
/Users/bear/src/oss/flatware/lib/flatware/sink.rb:1: warning: drb/drb is found
in drb, which will no longer be part of the default gems since Ruby 3.4.0. 
Add drb to your Gemfile or gemspec.
```