### PR TITLE
remove eol rubies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         rspec-minor-versions: [6, 7, 8, 9, 10, 11, 12, 13]
-        ruby-versions: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby-versions: ["3.1", "3.2", "3.3"]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rspec_3.${{ matrix.rspec-minor-versions }}.gemfile
 


### PR DESCRIPTION
Remove [EOL rubies](https://www.ruby-lang.org/en/downloads/branches/) from CI workflow