### PR TITLE
Fix a circular require call

### DIFF
--- a/lib/flatware/rspec.rb
+++ b/lib/flatware/rspec.rb
@@ -2,7 +2,6 @@
 
 require 'rspec/core'
 require 'rspec/expectations'
-require 'flatware/rspec/cli'
 
 module Flatware
   module RSpec


### PR DESCRIPTION
I noticed that there is a circular require in `flatware`. Normally you may not notice this easily, but you can quickly reproduce this when you add a `-w` option (stands for "warning") to `irb` and call `require 'flatware-rspec'`. I also think `Flatware::RSpec`  may not depend on it, so it should be safe to remove this call.

```
$ irb -w
> require 'flatware-rspec'
<internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136: warning: <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136: warning: loading in progress, circular require considered harmful - /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware-rspec.rb
	from /Users/yuki/.rbenv/versions/3.3.5/bin/irb:25:in  `<main>'
	from /Users/yuki/.rbenv/versions/3.3.5/bin/irb:25:in  `load'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/exe/irb:9:in  `<top (required)>'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:904:in  `start'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1020:in  `run'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1020:in  `catch'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1021:in  `block in run'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1040:in  `eval_input'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1117:in  `each_top_level_statement'
	from <internal:kernel>:187:in  `loop'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1120:in  `block in each_top_level_statement'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1041:in  `block in eval_input'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1388:in  `signal_status'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1049:in  `block (2 levels) in eval_input'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/context.rb:601:in  `evaluate'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/context.rb:633:in  `evaluate_expression'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/workspace.rb:121:in  `evaluate'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/workspace.rb:121:in  `eval'
	from (irb):1:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:135:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:141:in  `rescue in require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:141:in  `require'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware-rspec.rb:1:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware/rspec.rb:5:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware/rspec/cli.rb:3:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-2.3.1/lib/flatware/cli.rb:83:in  `<top (required)>'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-2.3.1/lib/flatware/cli.rb:83:in  `map'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-2.3.1/lib/flatware/cli.rb:84:in  `block in <top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'

<internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136: warning: <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136: warning: loading in progress, circular require considered harmful - /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware/rspec.rb
	from /Users/yuki/.rbenv/versions/3.3.5/bin/irb:25:in  `<main>'
	from /Users/yuki/.rbenv/versions/3.3.5/bin/irb:25:in  `load'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/exe/irb:9:in  `<top (required)>'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:904:in  `start'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1020:in  `run'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1020:in  `catch'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1021:in  `block in run'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1040:in  `eval_input'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1117:in  `each_top_level_statement'
	from <internal:kernel>:187:in  `loop'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1120:in  `block in each_top_level_statement'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1041:in  `block in eval_input'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1388:in  `signal_status'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb.rb:1049:in  `block (2 levels) in eval_input'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/context.rb:601:in  `evaluate'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/context.rb:633:in  `evaluate_expression'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/workspace.rb:121:in  `evaluate'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/workspace.rb:121:in  `eval'
	from (irb):1:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:135:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:141:in  `rescue in require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:141:in  `require'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware-rspec.rb:1:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware/rspec.rb:5:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from /Users/yuki/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/flatware-rspec-2.3.1/lib/flatware/rspec/cli.rb:4:in  `<top (required)>'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/Users/yuki/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
```