### PR TITLE
Address rubocop offences

### DIFF
--- a/features/step_definitions/flatware_steps.rb
+++ b/features/step_definitions/flatware_steps.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'benchmark'
 require 'etc'
 
 # helper methods available in all steps
@@ -27,11 +28,8 @@ module Support
     all_commands.find { |command| command.commandline.include? 'flatware' }
   end
 
-  def duration(&_block)
-    started_at = Time.now
-    yield
-  ensure
-    Time.now - started_at
+  def duration(&block)
+    Benchmark.realtime(&block)
   end
 end
 World(Support)


### PR DESCRIPTION
The Rubocop checks are failing with the latest Rubocop version (e.g. [build#74](https://github.com/briandunn/flatware/actions/runs/11301151217/job/31435145556?pr=98#step:4:14)):

```
Running RuboCop...
RuboCop failed!
Inspecting 63 files
....W..........................................................

Offenses:

features/step_definitions/flatware_steps.rb:34:14: W: [Correctable] Lint/Void: Operator - used in void context.
    Time.now - started_at
             ^

63 files inspected, 1 offense detected, 1 offense autocorrectable
```

However, when I run `bundle exec rubocop -a` to auto-fix them, the code ends up with an incorrect fix:

```diff
diff --git a/features/step_definitions/flatware_steps.rb b/features/step_definitions/flatware_steps.rb
index 1728508..6899b1f 100644
--- a/features/step_definitions/flatware_steps.rb
+++ b/features/step_definitions/flatware_steps.rb
@@ -28,10 +28,10 @@ module Support
   end

   def duration(&_block)
-    started_at = Time.now
+    Time.now
     yield
   ensure
-    Time.now - started_at
+    Time.now
   end
 end
 World(Support)
```

I believe that what we want to do with this method is to just measure how long the given block takes to execute, and we should be able to do that with the `Benchmark` module, which should be more appropriate:

```ruby
Benchmark.realtime { slow_method }
# => returns the time taken to execute the #slow_method, in float.
```