### PR TITLE
Address warnings for logger and ostruct

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gemspec name: 'flatware-cucumber'
 group :development do
   gem 'appraisal'
   gem 'aruba', '~> 0.14'
+  gem 'logger'
+  gem 'ostruct'
   gem 'pry'
   gem 'racc'
   gem 'rake'


### PR DESCRIPTION
There are a few warnings displayed when I run the `bundle exec rake` command:

```
flatware/spec/spec_helper.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```

```
gems/cucumber-3.2.0/lib/cucumber/formatter/legacy_api/adapter.rb:9: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

We can address these by adding `loggee` and `ostruct` to the Gemfile.

There are other warnings from Cucumber, but that's not something we can address from outside of the dependency.