### PR TITLE
remove support for eol ruby 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         rspec-minor-versions: [6, 7, 8, 9, 10, 11, 12, 13]
-        ruby-versions: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        ruby-versions: ["3.2", "3.3", "3.4", "4.0"]
         exclude:
           - ruby-versions: 4.0
             rspec-minor-versions: 6

--- a/flatware-cucumber.gemspec
+++ b/flatware-cucumber.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
             )
   s.homepage = 'http://github.com/briandunn/flatware'
   s.licenses = ['MIT']
-  s.required_ruby_version = ['>= 2.6', '< 4.1']
+  s.required_ruby_version = ['>= 3.2', '< 4.1']
   s.require_paths = ['lib']
   s.add_dependency %(cucumber), '>= 10.0'
   s.add_dependency %(flatware), Flatware::VERSION

--- a/flatware-rspec.gemspec
+++ b/flatware-rspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
           )
   s.homepage = 'http://github.com/briandunn/flatware'
   s.licenses = ['MIT']
-  s.required_ruby_version = ['>= 2.6', '< 4.1']
+  s.required_ruby_version = ['>= 3.2', '< 4.1']
   s.require_paths = ['lib']
   s.add_dependency %(flatware), Flatware::VERSION
   s.add_dependency %(rspec), '>= 3.6'

--- a/flatware.gemspec
+++ b/flatware.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/briandunn/flatware'
 
   s.licenses = ['MIT']
-  s.required_ruby_version = ['>= 2.6', '< 4.1']
+  s.required_ruby_version = ['>= 3.2', '< 4.1']
   s.require_paths = ['lib']
   s.executables = ['flatware']
   s.add_dependency %(benchmark)


### PR DESCRIPTION
Remove support for ruby 3.1, as suggested [here](https://github.com/briandunn/flatware/pull/114#issuecomment-3848460902)