### PR TITLE
Add after_forks_complete configuration hook

### DIFF
--- a/lib/flatware/configuration.rb
+++ b/lib/flatware/configuration.rb
@@ -22,9 +22,18 @@ module Flatware
       end
     end
 
+    def after_forks_complete(&block)
+      if block_given?
+        @after_forks_complete = block
+      else
+        @after_forks_complete
+      end
+    end
+
     def reset!
       @before_fork = -> {}
       @after_fork = ->(_) {}
+      @after_forks_complete = -> {}
     end
   end
 

--- a/lib/flatware/sink.rb
+++ b/lib/flatware/sink.rb
@@ -85,6 +85,7 @@ module Flatware
       def check_finished!
         return unless [workers, remaining_work].all?(&:empty?)
 
+        Flatware.configuration.after_forks_complete.call
         DRb.stop_service
         summarize
       end

--- a/spec/flatware/configuration_spec.rb
+++ b/spec/flatware/configuration_spec.rb
@@ -8,6 +8,20 @@ describe Flatware::Configuration do
     expect do
       Flatware.configuration.before_fork.call
       Flatware.configuration.after_fork.call(nil)
+      Flatware.configuration.after_forks_complete.call
     end.to_not raise_error
+  end
+
+  describe '#after_forks_complete' do
+    after { Flatware.configuration.reset! }
+
+    it 'stores and returns the given block' do
+      called = false
+      Flatware.configure do |config|
+        config.after_forks_complete { called = true }
+      end
+      Flatware.configuration.after_forks_complete.call
+      expect(called).to be true
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds an `after_forks_complete` hook to `Flatware::Configuration`, called once in the sink process after all workers have finished and all work is complete (just before `DRb.stop_service`).

This complements the existing `before_fork` and `after_fork` hooks by providing a place to run teardown logic that should happen exactly once after the entire parallel run — for example, cleaning up shared test databases or aggregating results.

### Usage

```ruby
Flatware.configure do |config|
  config.after_forks_complete do
    # runs once after all workers finish
  end
end
```

### Changes

- `lib/flatware/configuration.rb` — adds `after_forks_complete` accessor with the same pattern as `before_fork` / `after_fork`
- `lib/flatware/sink.rb` — calls the hook in `check_finished!` before stopping DRb
- `spec/flatware/configuration_spec.rb` — tests default noop behavior and block storage

## Test plan

- [x] Existing specs pass
- [x] New spec verifies default is a callable noop
- [x] New spec verifies the configured block is invoked