### PR TITLE
Update README to address Simplecov intermittently dropping coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,58 @@ Now when I run `bundle exec flatware rspec -r ./spec/flatware_helper` My app onl
 
 ## SimpleCov
 
-If you're using SimpleCov, follow [their directions](https://github.com/simplecov-ruby/simplecov/tree/main?tab=readme-ov-file#use-it-with-any-framework) to install. When you have it working as desired for serial runs, add
-`SimpleCov.at_fork.call(test_env_number)` to flatware's `after_fork` hook. You should now get the same coverage stats from parallel and serial runs.
+If you're using SimpleCov, follow [their directions](https://github.com/simplecov-ruby/simplecov/tree/main?tab=readme-ov-file#use-it-with-any-framework) to install. When you have it working as desired for serial runs, add `SimpleCov.at_fork.call(test_env_number)` to flatware's `after_fork` hook. You should now get the same coverage stats from parallel and serial runs.
+
+### Avoiding the parent / worker merge race
+
+`flatware rspec` reaches its top-level `exit` as soon as the DRb sink has seen every worker report its final result — but a worker's `at_exit` (where SimpleCov writes its resultset slice via `SimpleCov::ResultMerger.store_result`) runs *after* that final report goes over the wire. Without an explicit barrier in the parent, its own SimpleCov `at_exit` (which merges every worker's slice into the final report) can fire before the slowest worker has finished writing. The symptom is an intermittent coverage drop, with one subprocess absent from the final `Coverage report generated for ...` listing and a different worker dropping out each run.
+
+Register a `Process.waitall` barrier in `before_fork`, gated to the parent process only:
+
+```ruby
+Flatware.configure do |conf|
+  conf.before_fork do
+    require 'rails_helper'
+
+    ActiveRecord::Base.connection.disconnect!
+
+    # `flatware rspec` exits when the DRb sink confirms every
+    # worker has reported its results — but a worker's at_exit
+    # (where SimpleCov stores its resultset slice) runs AFTER
+    # that report goes over the wire. Block the parent's own
+    # at_exit handlers until every child has fully exited so
+    # SimpleCov's merge sees the complete set of slices.
+    # LIFO at_exit ordering means this handler, registered
+    # AFTER `require 'rails_helper'` loaded SimpleCov, fires
+    # FIRST — by the time SimpleCov's at_exit runs its merge,
+    # every worker has fully exited and committed its data.
+    # Workers inherit the handler at fork time; the
+    # `Process.pid != parent_pid` short-circuit no-ops it in
+    # every child.
+    parent_pid = Process.pid
+     at_exit do
+      next if Process.pid != parent_pid
+
+      begin
+        Process.waitall
+      rescue Errno::ECHILD
+        # No remaining children — already reaped elsewhere.
+      end
+    end
+  end
+
+  conf.after_fork do |test_env_number|
+    SimpleCov.at_fork.call(test_env_number)
+
+    # If you use SimpleCov.minimum_coverage_by_file in CI, also
+    # clear it inside the worker — SimpleCov.at_fork's default
+    # lambda clears the aggregate `minimum_coverage` but not the
+    # per-file one, so workers will otherwise kill themselves on
+    # the per-file 100% check before their slice can merge:
+    # SimpleCov.minimum_coverage_by_file 0
+  end
+end
+```
 
 ## Segmentation faults in the PG gem
 
@@ -189,10 +239,3 @@ Do whatever you want. I'd love to help make sure Flatware meets your needs.
 [![Hashrocket logo](https://hashrocket.com/hashrocket_logo.svg)](https://hashrocket.com)
 
 Flatware is supported by the team at [Hashrocket](https://hashrocket.com), a multidisciplinary design & development consultancy. If you'd like to [work with us](https://hashrocket.com/contact-us/hire-us) or [join our team](https://hashrocket.com/contact-us/jobs), don't hesitate to get in touch.
-
-
-# TODO:
-
-possible simplecov fixes
-
-1. seems like we won't get the same results as serial rspec runs unless we start simplecov after fork. And if we do that, I think a process needs to claim to be the last one for simplecov to run the merge.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,12 @@ Now when I run `bundle exec flatware rspec -r ./spec/flatware_helper` My app onl
 
 ## SimpleCov
 
-If you're using SimpleCov, follow [their directions](https://github.com/simplecov-ruby/simplecov/tree/main?tab=readme-ov-file#use-it-with-any-framework) to install. When you have it working as desired for serial runs, add `SimpleCov.at_fork.call(test_env_number)` to flatware's `after_fork` hook. You should now get the same coverage stats from parallel and serial runs.
+If you're using SimpleCov, follow [their directions](https://github.com/simplecov-ruby/simplecov/tree/main?tab=readme-ov-file#use-it-with-any-framework) to install. Each worker has to re-arm coverage after the fork so its slice gets written and merged, and flatware's `after_fork` hook is where that happens — but whether you have to do it by hand depends on your SimpleCov version and configuration:
+
+- **SimpleCov 1.0+ with subprocess merging enabled** hooks `Process._fork` itself and calls `SimpleCov.at_fork` in the child for you. `SimpleCov.start "rails"` enables it, as does setting `SimpleCov.merge_subprocesses true`. Don't call `at_fork` again here: the default `at_fork` names each slice by appending its ordinal to the current `command_name`, so a second call produces `RSpec (subprocess: 1) (subprocess: 1)` for every worker in the merged report.
+- **Anything else** needs `SimpleCov.at_fork.call(test_env_number)` in `after_fork` yourself. That covers a bare `SimpleCov.start`, which enables no subprocess merging and so installs no hook, and SimpleCov 0.22, which hooks `Process.fork` by alias — flatware forks with a bare `Kernel#fork`, which bypasses that but does route through `Process._fork`.
+
+`SimpleCov.enabled_for_subprocesses?` tells you which case you're in. Either way you should now get the same coverage stats from parallel and serial runs.
 
 ### Avoiding the parent / worker merge race
 
@@ -167,7 +172,7 @@ Flatware.configure do |conf|
     # `Process.pid != parent_pid` short-circuit no-ops it in
     # every child.
     parent_pid = Process.pid
-     at_exit do
+    at_exit do
       next if Process.pid != parent_pid
 
       begin
@@ -179,14 +184,21 @@ Flatware.configure do |conf|
   end
 
   conf.after_fork do |test_env_number|
-    SimpleCov.at_fork.call(test_env_number)
+    # Uncomment only if SimpleCov isn't hooking fork itself (see
+    # above). This example loads a Rails app, which typically
+    # means `SimpleCov.start "rails"` — that enables subprocess
+    # merging, so at_fork has already run in this child and a
+    # second call would double every slice's name.
+    # SimpleCov.at_fork.call(test_env_number)
 
-    # If you use SimpleCov.minimum_coverage_by_file in CI, also
-    # clear it inside the worker — SimpleCov.at_fork's default
-    # lambda clears the aggregate `minimum_coverage` but not the
-    # per-file one, so workers will otherwise kill themselves on
-    # the per-file 100% check before their slice can merge:
-    # SimpleCov.minimum_coverage_by_file 0
+    # If you gate CI on a per-file threshold, clear it inside the
+    # worker — at_fork's default lambda clears the aggregate
+    # `minimum_coverage` but not the per-file one, so workers will
+    # otherwise kill themselves on the per-file % check before
+    # their slice can merge. The parent's at_exit still enforces
+    # both against the merged report.
+    SimpleCov.coverage(:line) { minimum_per_file 0 } # 1.0+
+    # SimpleCov.minimum_coverage_by_file 0           # 0.22
   end
 end
 ```


### PR DESCRIPTION
Two related fixes to the SimpleCov section of the README, plus removal of the `# TODO: possible simplecov fixes` block at the bottom, since between them these answer it.

**1. The parent / worker merge race**

After first integrating flatware, I've seen 2% drops in coverage in every 1-in-3 full suite runs, with a different worker missing from the final `Coverage report generated for ...` listing each time.

From what I can tell, `flatware rspec` returns to its top-level exit the moment the DRb sink has seen every worker report its final result — but a worker's `at_exit` (where SimpleCov stores its resultset slice to disk) runs after the last DRb report goes over the wire. So the parent's own SimpleCov `at_exit` (which merges all workers' slices into the final report) can fire before the slowest worker finishes writing.

The solution appears to be adding a `Process.waitall` barrier inside an `at_exit` registered from `before_fork` (after `require 'rails_helper'` has loaded SimpleCov). LIFO `at_exit` ordering means the barrier fires before SimpleCov's `at_exit`, so the merge sees the full set of workers' resultsets. The handler is gated to `Process.pid == parent_pid`; it no-ops in worker forks.

I'm running this setup in production now and have not seen any coverage drops.

This is also what the TODO's item 1 was after — "a process needs to claim to be the last one for simplecov to run the merge" — so I've removed that block.

**2. On SimpleCov 1.0, at_fork is already called for you**

My previously-added advice in 54232f8 to add `SimpleCov.at_fork.call(test_env_number)` to `after_fork` (written for SimpleCov 0.22) is now wrong for most Rails readers, because of two changes in SimpleCov 1.0:

  - The `fork` hook moved to `Process._fork`. 0.22 patched `Process.fork` by alias, which a bare `Kernel#fork` bypasses — and flatware forks with a bare `fork` (cli.rb, worker.rb). So on 0.22 the hook never fired for flatware and the manual call was genuinely needed. 1.0 prepends to `Process._fork`, the official extension point every fork path funnels through, so it now does fire here and calls `SimpleCov.at_fork` in the child itself.
  - The rails profile enables subprocess merging. The hook is only installed when `enabled_for_subprocesses?`, and 1.0's rails profile turns that on (0.22's didn't). So `SimpleCov.start "rails"` opts you in without asking.

Together that means my previously documented call ran the default `at_fork` twice per worker. Since it names each slice by appending its ordinal to the current command_name, every worker lands in the merged report as `RSpec (subprocess: 1) (subprocess: 1)`.

I've split the guidance by case in c3ce137 rather than dropping the call, since it's still correct whenever the hook isn't installed, and pointed at `SimpleCov.enabled_for_subprocesses?` as the way to tell which case you're in.